### PR TITLE
refactor: unnecessary imports removed

### DIFF
--- a/src/MemoryLeak/MemoryLeak/Controllers/DiagnosticsController.cs
+++ b/src/MemoryLeak/MemoryLeak/Controllers/DiagnosticsController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace MemoryLeak.Controllers


### PR DESCRIPTION
The `System.Runtime.InteropServices` import has been removed from the `DiagnosticsController` controller.